### PR TITLE
Eeprom logo bmp loader

### DIFF
--- a/MaxDuino/CheckForExt.cpp
+++ b/MaxDuino/CheckForExt.cpp
@@ -25,7 +25,7 @@
   #include "c64tap.h"
 #endif
 
-void checkForEXT(const char * const filenameExt) {
+void checkForEXT() {
   //Check for .xxx file extension as these have no header
 
 #ifdef Use_CAS
@@ -127,6 +127,6 @@ else if (!strcasecmp_P(filenameExt, PSTR("caq"))) {
   else if (!strcasecmp_P(filenameExt, PSTR("cdt"))) {
     AMScdt = true;
   }
-#endif  
+#endif
 }
 

--- a/MaxDuino/CheckForExt.h
+++ b/MaxDuino/CheckForExt.h
@@ -1,6 +1,6 @@
 #ifndef CHECK_FOR_EXT_H_INCLUDED
 #define CHECK_FOR_EXT_H_INCLUDED
 
-void checkForEXT(const char * const filenameExt);
+void checkForEXT();
 
 #endif // CHECK_FOR_EXT_H_INCLUDED

--- a/MaxDuino/Display.cpp
+++ b/MaxDuino/Display.cpp
@@ -280,7 +280,7 @@ char fline[17];
     }
   }
 
-  #if defined(LOAD_EEPROM_LOGO) || defined(LOAD_MEM_LOGO)
+#if defined(HAS_LOGO)
   #if defined(LOGO_FADE_IN)
   inline byte attract_mask(word screen_address, byte frame)
   {
@@ -305,9 +305,68 @@ char fline[17];
   }
   #endif
 
+  #if defined(LOAD_EEPROM_LOGO) || defined(LOAD_EEPROM_LOGO_MEM_FALLBACK)
+  inline byte load_eeprom_logo_byte(byte i, byte j)
+  {
+    byte t;
+    #if not defined(EEPROM_LOGO_COMPRESS)
+      EEPROM_read_logo_byte(j*128+i, t);
+    #elif defined(EEPROM_LOGO_COMPRESS)
+      if (i%2 == 0){
+        t=0;
+        #ifdef OLED1306_128_64
+          if (j%2 == 0) {
+            byte ril=0;
+            byte ib=0;
+            EEPROM_read_logo_byte((j/2)*64+i/2, ril);
+
+            for(ib=0;ib<4;ib++) {
+              if (bitRead (ril,ib)) {
+                t |= (1 << ib*2);
+                #ifdef COMPRESS_REPEAT_ROW
+                  t |= (1 << (ib*2)+1);
+                #endif
+              }
+            }
+          } else {
+            byte rih=0;
+            byte ic=0;
+            EEPROM_read_logo_byte((j/2)*64+i/2, rih);
+
+            for(ic=4;ic<8;ic++) {
+              if (bitRead (rih,ic)) {
+                t |= (1 << (ic-4)*2);
+                #ifdef COMPRESS_REPEAT_ROW
+                  t |= (1 << ((ic-4)*2)+1);
+                #endif
+              }
+            }
+          }
+        #else
+          EEPROM_read_logo_byte(j*64+i/2, t);
+        #endif
+      }
+    #endif
+    return t;
+  }
+  #endif
+
+  #if defined(LOAD_MEM_LOGO) || defined(LOAD_EEPROM_LOGO_MEM_FALLBACK)
+  inline byte load_mem_logo_byte(byte i, byte j)
+  {
+    return pgm_read_byte(logo+j*128+i);
+  }
+  #endif
+
   void load_logo()
   {
     // read logo from eeprom and write to screen
+    #if defined(LOAD_EEPROM_LOGO_MEM_FALLBACK)
+    bool found_eeprom_logo = EEPROM_check_logo_valid();
+    Serial.print("found_eeprom_logo=");
+    Serial.println(found_eeprom_logo);
+    #endif
+
     byte t;
     #if defined(LOGO_FADE_IN)
     unsigned long start_time = millis();
@@ -323,49 +382,16 @@ char fline[17];
       setXY(0,j);
       for(byte i=0;i<128;i++)     // show 128* 32 Logo
       {
-
-      #if defined(LOAD_EEPROM_LOGO)
-        #if not defined(EEPROM_LOGO_COMPRESS)
-          EEPROM_read_logo_byte(j*128+i, t);
-        #elif defined(EEPROM_LOGO_COMPRESS)
-          if (i%2 == 0){
-            t=0;
-            #ifdef OLED1306_128_64
-              if (j%2 == 0) {
-                byte ril=0;
-                byte ib=0;
-                EEPROM_read_logo_byte((j/2)*64+i/2, ril);
-
-                for(ib=0;ib<4;ib++) {
-                  if (bitRead (ril,ib)) {
-                    t |= (1 << ib*2);
-                    #ifdef COMPRESS_REPEAT_ROW
-                      t |= (1 << (ib*2)+1);
-                    #endif
-                  }
-                }
-              } else {
-                byte rih=0;
-                byte ic=0;
-                EEPROM_read_logo_byte((j/2)*64+i/2, rih);
-
-                for(ic=4;ic<8;ic++) {
-                  if (bitRead (rih,ic)) {
-                    t |= (1 << (ic-4)*2);
-                    #ifdef COMPRESS_REPEAT_ROW
-                      t |= (1 << ((ic-4)*2)+1);
-                    #endif
-                  }
-                }
-              }
-            #else
-              EEPROM_read_logo_byte(j*64+i/2, t);
-            #endif
-          }
+        #if defined(LOAD_EEPROM_LOGO_MEM_FALLBACK)
+          if (found_eeprom_logo)
+            t = load_eeprom_logo_byte(i, j);
+          else
+            t = load_mem_logo_byte(i, j);
+        #elif defined(LOAD_EEPROM_LOGO)
+          t = load_eeprom_logo_byte(i, j);
+        #else
+          t = load_mem_logo_byte(i, j);
         #endif
-      #else
-        t = pgm_read_byte(logo+j*128+i);
-      #endif
 
         #if defined(LOGO_FADE_IN)
         byte mask = attract_mask(j*128+i, frame);
@@ -374,6 +400,7 @@ char fline[17];
         SendByte(t);
       }  
     }
+
     #if defined(LOGO_FADE_IN)
     // LOGO_FADE_IN defines the number of millseconds for the animation
     const unsigned long millis_per_frame = (LOGO_FADE_IN/128);
@@ -390,7 +417,7 @@ char fline[17];
     }  
     #endif
   }
-  #endif // LOAD_EEPROM_LOGO || LOAD_MEM_LOGO
+#endif // HAS_LOGO
 
   #if defined(RECORD_EEPROM_LOGO)
   void record_eeprom_logo()
@@ -526,7 +553,7 @@ char fline[17];
     // sendcommand(0xA6); // SSD1306_NORMALDISPLAY
     // sendcommand(0x2E); // SSD1306_DEACTIVATE_SCROLL
 
-    #if defined(LOAD_MEM_LOGO) || defined(LOAD_EEPROM_LOGO)
+    #if defined(HAS_LOGO)
       sendcommand(0xAF);    //display on
       load_logo();
     #endif

--- a/MaxDuino/Display.cpp
+++ b/MaxDuino/Display.cpp
@@ -81,6 +81,26 @@ char fline[17];
     mx_i2c_end();         
   }   
 
+  #if defined(EEPROM_LOGO_BMP_LOADER)
+  //==========================================================//
+  // Set the address to a pixel X and pixelrow row
+  void setByteXY(unsigned char x, unsigned char row)
+  {
+    mx_i2c_start(OLED_address);
+    mx_i2c_write(0x80);  
+    mx_i2c_write(0xb0+(row)); //set page address (row)
+    mx_i2c_write(0x80); //command mode
+    #ifdef OLED1106_1_3            
+      mx_i2c_write( 0x02+(x%16)); //set low col address
+    #else
+      mx_i2c_write( 0x00+(x%16)); //set low col address
+    #endif
+    mx_i2c_write(0x80); 
+    mx_i2c_write(0x10+(x/16)); //set high col address 
+    mx_i2c_end();         
+  }
+  #endif
+
   //==========================================================//
   // Prints a string regardless the cursor position.
   void sendStr(const __FlashStringHelper *string)

--- a/MaxDuino/Display.h
+++ b/MaxDuino/Display.h
@@ -23,6 +23,9 @@
   void displayOff(void);
   void clear_display(void);
   void init_OLED(void);
+  #if defined(EEPROM_LOGO_BMP_LOADER)
+  void setByteXY(unsigned char x, unsigned char row);
+  #endif
 
   #if defined(XY2) && not defined(DoubleFont)
     PROGMEM const byte DFONT[16] = { 0x00, 0x03, 0x0C, 0x0F, 0x30, 0x33, 0x3C, 0x3F, 0xC0, 0xC3, 0xCC, 0xCF, 0xF0, 0xF3, 0xFC, 0xFF };

--- a/MaxDuino/Display.h
+++ b/MaxDuino/Display.h
@@ -39,6 +39,16 @@
     #endif
   #endif
 
+  #if defined(LOAD_MEM_LOGO) || defined(LOAD_EEPROM_LOGO) || defined(LOAD_EEPROM_LOGO_MEM_FALLBACK)
+  #define HAS_LOGO
+  #endif
+
+  #if defined(OLED1306_128_64) || defined(video64text32)
+  #define LOGO_SIZE_BYTES 1024 /* 128x64 */
+  #else
+  #define LOGO_SIZE_BYTES 512 /* 128x32 */
+  #endif
+
 
 #elif defined(P8544)
   #define SCREENSIZE 14

--- a/MaxDuino/EEPROM_bmp_loader.cpp
+++ b/MaxDuino/EEPROM_bmp_loader.cpp
@@ -1,0 +1,165 @@
+#include "configs.h"
+
+#ifdef EEPROM_LOGO_BMP_LOADER
+#include "Arduino.h"
+#include "EEPROM_bmp_loader.h"
+#include "EEPROM_wrappers.h"
+#include "file_utils.h"
+#include "Display.h"
+#include "buttons.h"
+
+static void read_display_sdcard_logo(byte invert, bool eeprom_write, bool compress)
+{
+  // we read the bitmap and display it, and (if flags are set) simultaneously write
+  // to EEPROM, either compressed or uncompressed
+  // If compression is enabled, what we display on the screen is consistent with the 'after compression' result
+  // (but you can toggle this if you want to see the original image without compression)
+ 
+  if (eeprom_write)
+    EEPROM_write_logo_begin();
+
+  #if defined(OLED1306_128_64) || defined(video64text32)
+    const byte J = 8;  // 8 LINES
+  #else
+    const byte J = 4;  // 4 LINES
+  #endif
+  byte v;
+  byte tmp[J];
+  for(byte i=0;i<128;i++)
+  {
+    // load a vertical strip from the BMP into the tmp buffer
+    // Why vertical? because one byte for the oled controller represents 8 vertical bits.
+    // starting at the top left,
+    // and (if compression is enabled) we compress vertical slices.
+    // This is made a bit more complicated by the fact that the .BMP is ordered horizontally
+    // rather than vertically, and bottom-to-top rather than top-to-bottom
+    if ((!compress) || (i%2==0))
+    {
+      for(byte j=0;j<J;j++)
+      { 
+        v = 0;
+        for(byte bit=0; bit<8; bit++)
+        {
+          readfile(1, 0x3E + (i>>3) + (128>>3)*bit + 128*(J-1-j));
+          v <<= 1;
+          v += (filebuffer[0] >> (7-(i & 7))) & 0x01;
+        }
+        v ^= invert;
+        tmp[j] = v;
+      }
+    }
+    // now modify the vertical strip that we have read, in-place, to match
+    // what it would look like after compression and decompression
+    if (compress)
+    {
+      for(byte j=0;j<J;j+=2)
+      {
+        byte compressed = 0;
+        for(byte shift=0; shift<1; shift++)
+        {
+          v = tmp[j+shift];
+          for (byte bit=7; bit>0; bit-=2)
+          {
+            byte pixel = (v>>bit)&0x01;
+
+            // compressed is what we will write to EEPROM
+            compressed <<= 1;
+            compressed += pixel;
+
+            // v is what we will write to the screen
+            v = (v&~(1<<(bit-1))) + (pixel<<(bit-1));
+          }
+          setByteXY(i, j+shift);
+          SendByte(v);
+          setByteXY(i+1, j+shift);
+          SendByte(v);
+        }
+        if (eeprom_write && i%2==0)
+        {
+          EEPROM_write_logo_byte((j/2)*64+(i/2), compressed);
+        }
+      }
+    }
+    else
+    {
+      for(byte j=0;j<J;j++)
+      { 
+        if (eeprom_write)
+        {
+          EEPROM_write_logo_byte(j*128+i, tmp[j]);
+        }
+        setByteXY(i, j);
+        SendByte(tmp[j]);
+      }
+    }
+  }
+
+if (eeprom_write)
+    EEPROM_write_logo_end();
+}
+
+
+bool EEPROM_bmp_load_file()
+{
+  // gets called when user clicks on a file
+  // check to see if it is a logo file (bitmap, etc)
+  // returns true if this was a logo file (regardless of whether it was written to eeprom or not)
+  // so that it doesn't get handled like an audio file
+  // Also: this is a whole separate event loop, like Menu.  This function exits when you click the STOP button.
+
+// #if defined(OLED1306_128_64) || defined(video64text32)
+//   // 128x64
+//   if ((!strcasecmp_P(filenameExt, PSTR("bmp"))) && (filesize==1086))
+// #else
+//   // 128x32
+//   if ((!strcasecmp_P(filenameExt, PSTR("bmp"))) && (filesize==574))
+// #endif
+//   {
+//     readfile(2, 0);
+//     if (filebuffer[0] == 'B' && filebuffer[1] == 'M') {
+//       read_display_sdcard_logo();
+//       return true;
+//     }
+//   }
+
+//   return false;
+  byte invert = 0;
+  #if defined(EEPROM_LOGO_COMPRESS)
+  bool compress = true;
+  #else
+  const bool compress = false;
+  #endif
+  clear_display();
+  read_display_sdcard_logo(invert, false, compress);
+  while(!button_stop() || lastbtn)
+  {
+    if (button_play())
+    {
+      printtextF(PSTR("WRITING EEPROM.."),0);
+      read_display_sdcard_logo(invert, true, compress);
+      printtextF(PSTR("SAVED TO EEPROM"),0);
+      delay(1500);
+      clear_display();
+      return true;
+    }
+    if (button_up())
+    {
+      invert ^= 0xff;
+      read_display_sdcard_logo(invert, false, compress);
+    }
+  #if defined(EEPROM_LOGO_COMPRESS)
+    if (button_down())
+    {
+      compress = !compress;
+      read_display_sdcard_logo(invert, false, compress);
+    }
+  #endif
+    checkLastButton();
+  }
+  debounce(button_stop);
+  clear_display();
+  return true;
+}
+
+
+#endif //EEPROM_LOGO_BMP_LOADER

--- a/MaxDuino/EEPROM_bmp_loader.h
+++ b/MaxDuino/EEPROM_bmp_loader.h
@@ -1,0 +1,8 @@
+#ifndef EEPROM_BMP_LOADER_H_INCLUDED
+#define EEPROM_BMP_LOADER_H_INCLUDED
+
+#ifdef EEPROM_LOGO_BMP_LOADER
+bool EEPROM_bmp_load_file();
+#endif
+
+#endif // EEPROM_BMP_LOADER_H_INCLUDED

--- a/MaxDuino/EEPROM_wrappers.cpp
+++ b/MaxDuino/EEPROM_wrappers.cpp
@@ -1,6 +1,7 @@
 #include "Arduino.h"
 #include "configs.h"
 #include "EEPROM_wrappers.h"
+#include "Display.h"
 
 #ifdef USES_EEPROM
 
@@ -46,7 +47,6 @@
       EEPROM_put(address, data);
     }
   }
-
 
 #elif defined(__arm__) && defined(__STM32F1__)
   #include <EEPROM.h>
@@ -218,6 +218,25 @@
 
 #else
   #error "EEPROM support required but no EEPROM library or compatibility layer has been implemented for this target"
+#endif
+
+#if defined(LOAD_EEPROM_LOGO_MEM_FALLBACK)
+  bool EEPROM_check_logo_valid()
+  {
+    // returns true if we believe there is a saved logo, and false if not.
+    // Because some config bytes are saved at the end of the logo on some devices,
+    // we skip the last two bytes.  It's good enough for now.
+    byte value;
+    EEPROM_read_logo_byte(0, value);
+    byte test_value;
+    for(uint16_t address=1; address<LOGO_SIZE_BYTES-2; address++)
+    {
+      EEPROM_read_logo_byte(address, test_value);
+      if(test_value != value)
+        return true;
+    }
+    return false;
+  }
 #endif
 
 #endif // USES_EEPROM

--- a/MaxDuino/EEPROM_wrappers.cpp
+++ b/MaxDuino/EEPROM_wrappers.cpp
@@ -35,7 +35,16 @@
   }
 
   void EEPROM_write_logo_byte(uint16_t address, byte data) {
-    EEPROM_put(address, data);
+    // protect config bytes, don't overwrite them
+    // should optimise to a no-op for devices where EEPROM_CONFIG_BYTES doesn't overlap with logo storage
+    #if defined(RECORD)
+    if (address%1023 != EEPROM_CONFIG_BYTEPOS && address%1023 != EEPROM_RECORD_CONFIG_BYTEPOS)
+    #else
+    if (address%1023 != EEPROM_CONFIG_BYTEPOS)
+    #endif
+    {
+      EEPROM_put(address, data);
+    }
   }
 
 
@@ -65,7 +74,16 @@
   }
 
   void EEPROM_write_logo_byte(uint16_t address, byte data) {
-    EEPROM_put(address, data);
+    // protect config bytes, don't overwrite them
+    // should optimise to a no-op for devices where EEPROM_CONFIG_BYTES doesn't overlap with logo storage
+    #if defined(RECORD)
+    if (address%1023 != EEPROM_CONFIG_BYTEPOS && address%1023 != EEPROM_RECORD_CONFIG_BYTEPOS)
+    #else
+    if (address%1023 != EEPROM_CONFIG_BYTEPOS)
+    #endif
+    {
+      EEPROM_put(address, data);
+    }
   }
 
 #elif defined(__SAMD21__) || defined(__SAMD21G18A__) || defined(ESP8266) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2350)
@@ -138,19 +156,28 @@
   }
 
   void EEPROM_write_logo_byte(uint16_t address, byte data) {
-    EEPROM_put(address, data);
+    // protect config bytes, don't overwrite them
+    // should optimise to a no-op for devices where EEPROM_CONFIG_BYTES doesn't overlap with logo storage
+    #if defined(RECORD)
+    if (address%1023 != EEPROM_CONFIG_BYTEPOS && address%1023 != EEPROM_RECORD_CONFIG_BYTEPOS)
+    #else
+    if (address%1023 != EEPROM_CONFIG_BYTEPOS)
+    #endif
+    {
+      EEPROM_put(address, data);
+    }
   }
 
 #elif defined(ESP32_XTENSA) || defined(ESP32_RISCV)
   #include <Preferences.h>
   Preferences prefs;
   
-  #if defined(LOAD_EEPROM_LOGO) || defined(RECORD_EEPROM_LOGO)
+  #if defined(HAS_EEPROM_LOGO)
   byte EEPROM_logo_bytes[1024];
   #endif
 
   void EEPROM_init() {
-  #if defined(LOAD_EEPROM_LOGO) || defined(RECORD_EEPROM_LOGO)
+  #if defined(HAS_EEPROM_LOGO)
     prefs.begin("maxduino", true);
     prefs.getBytes("logo", EEPROM_logo_bytes, 1024);
     prefs.end();
@@ -169,7 +196,7 @@
     prefs.end();
   }
 
-  #if defined(LOAD_EEPROM_LOGO) || defined(RECORD_EEPROM_LOGO)
+  #if defined(HAS_EEPROM_LOGO)
   void EEPROM_write_logo_begin() {
   }
 

--- a/MaxDuino/EEPROM_wrappers.h
+++ b/MaxDuino/EEPROM_wrappers.h
@@ -6,7 +6,7 @@
 #include "Arduino.h"
 #include "configs.h"
 
-#if defined(LOAD_EEPROM_SETTINGS) || defined(RECORD_EEPROM_LOGO) || defined(LOAD_EEPROM_LOGO)
+#if defined(LOAD_EEPROM_SETTINGS) || defined(RECORD_EEPROM_LOGO) || defined(LOAD_EEPROM_LOGO) || defined(EEPROM_LOGO_BMP_LOADER)
 #define USES_EEPROM
 #endif
 

--- a/MaxDuino/EEPROM_wrappers.h
+++ b/MaxDuino/EEPROM_wrappers.h
@@ -6,7 +6,11 @@
 #include "Arduino.h"
 #include "configs.h"
 
-#if defined(LOAD_EEPROM_SETTINGS) || defined(RECORD_EEPROM_LOGO) || defined(LOAD_EEPROM_LOGO) || defined(EEPROM_LOGO_BMP_LOADER)
+#if defined(RECORD_EEPROM_LOGO) || defined(LOAD_EEPROM_LOGO) || defined(EEPROM_LOGO_BMP_LOADER)
+#define HAS_EEPROM_LOGO
+#endif
+
+#if defined(LOAD_EEPROM_SETTINGS) || defined(HAS_EEPROM_LOGO)
 #define USES_EEPROM
 #endif
 

--- a/MaxDuino/EEPROM_wrappers.h
+++ b/MaxDuino/EEPROM_wrappers.h
@@ -6,7 +6,7 @@
 #include "Arduino.h"
 #include "configs.h"
 
-#if defined(RECORD_EEPROM_LOGO) || defined(LOAD_EEPROM_LOGO) || defined(EEPROM_LOGO_BMP_LOADER)
+#if defined(RECORD_EEPROM_LOGO) || defined(LOAD_EEPROM_LOGO) || defined(LOAD_EEPROM_LOGO_MEM_FALLBACK) || defined(EEPROM_LOGO_BMP_LOADER)
 #define HAS_EEPROM_LOGO
 #endif
 
@@ -22,6 +22,9 @@ void EEPROM_read_configbyte(byte &data);
 void EEPROM_write_configbyte(byte data);
 void EEPROM_read_logo_byte(uint16_t address, byte& data);
 void EEPROM_write_logo_byte(uint16_t address, byte data);
+#if defined(LOAD_EEPROM_LOGO_MEM_FALLBACK)
+bool EEPROM_check_logo_valid();
+#endif
 #if defined(RECORD)
 void EEPROM_read_record_configbyte(byte &data);
 void EEPROM_write_record_configbyte(byte data);

--- a/MaxDuino/MaxDuino.ino
+++ b/MaxDuino/MaxDuino.ino
@@ -52,6 +52,9 @@
 #include "power.h"
 #include "EEPROM_wrappers.h"
 #include "record.h"
+#ifdef EEPROM_LOGO_BMP_LOADER
+  #include "EEPROM_bmp_loader.h"
+#endif
 
 
 const char TXT_PAUSED[] PROGMEM =  "Paused  ";
@@ -63,6 +66,7 @@ SdBaseFile *currentDir = &_tmpdirs[0];  // SD card directory
 byte _alt_tmp_dir = 1; // which of the _tmpdirs is scratch (we flip this between 0 and 1)
 
 char fileName[filenameLength + 1];    //Current filename
+const char * filenameExt;             //File extension of the current filename (after the .), if any
 char prevSubDir[SCREENSIZE+1];
 uint16_t DirFilePos[nMaxPrevSubDirs];  //File Positions in Directory to be restored (also, history of subdirectories)
 byte subdir = 0;
@@ -886,19 +890,35 @@ void playFile() {
     //If selected file is a directory move into directory
     changeDir();
   }
-  else if (!dirEmpty) 
+  else if (!dirEmpty && entry.open(currentDir, currentFile, O_RDONLY))
   {
-    printtextF(TXT_PLAYING,0);
-    pauseOn = false;
-    scrollText(fileName, isDir, 0);
-    currpct=100;
-    lcdsegs=0;
-    UniPlay();
+    filenameExt = strrchr(fileName,'.') + 1;
+    #ifdef EEPROM_LOGO_BMP_LOADER
+      if (!strcasecmp_P(filenameExt, PSTR("bmp")) && EEPROM_bmp_load_file())
+      {
+        // done
+        entry.close();
+        seekFile(); 
+        #if defined(OLED1306) && defined(OSTATUSLINE)
+          OledStatusLine();
+        #endif
+        return;
+      }
+      else
+    #endif
+    {
+      printtextF(TXT_PLAYING,0);
+      pauseOn = false;
+      scrollText(fileName, isDir, 0);
+      currpct=100;
+      lcdsegs=0;
+      UniPlay();
       #ifdef P8544
         lcd.gotoRc(3,38);
         lcd.bitmap(Play, 1, 6);
-      #endif      
-    start=1;       
+      #endif
+      start=1;
+    }
   }    
 }
 

--- a/MaxDuino/MaxDuino.ino
+++ b/MaxDuino/MaxDuino.ino
@@ -113,12 +113,33 @@ byte oldMaxBlock = maxblock-1;
 
 bool firstBlockPause = false;
 
-#if (SPLASH_SCREEN && TIMEOUT_RESET)
+#if (SPLASH_SCREEN && TIMEOUT_RESET) || defined(MENU_HAS_REBOOT)
+  #if defined(__AVR__)
+    // Restarts program from beginning but does not reset the peripherals and registers
     void(* resetFunc) (void) = 0;//declare reset function at adress 0
-    /*void resetFunc() // Restarts program from beginning but does not reset the peripherals and registers
-    {
-    asm volatile ("  jmp 0");
-    }*/
+   #elif defined(__SAMD21__)
+   void _resetFunc(void)
+   {
+      noInterrupts(); 
+      NVIC_SystemReset(); 
+      while (1); 
+   }
+   void(* resetFunc) (void) = _resetFunc;
+   #elif defined(ESP32_XTENSA) || defined(ESP32_RISCV) || defined(ESP8266)
+   void _resetFunc(void)
+   {
+     ESP.restart();
+   }
+   void(* resetFunc) (void) = _resetFunc;
+   #elif defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_RP2350)
+   void _resetFunc(void)
+   {
+     rp2040.reboot(); 
+   }
+   void(* resetFunc) (void) = _resetFunc;
+   #else
+   #error resetFunc not implemented for this device
+   #endif
 #endif
 
 void setup() {
@@ -148,7 +169,7 @@ void setup() {
   #ifdef OLED1306
     init_OLED();
     #if (!SPLASH_SCREEN)
-      #if defined(LOAD_MEM_LOGO) || defined(LOAD_EEPROM_LOGO)
+      #if defined(HAS_LOGO)
         delay(1500);             // Show logo
       #endif
       reset_display();           // Clear logo and load saved mode

--- a/MaxDuino/MaxProcessing.cpp
+++ b/MaxDuino/MaxProcessing.cpp
@@ -84,15 +84,11 @@ word TickToUs(word ticks) {
 void UniPlay(){
   // initialise scale and period based on current BAUDRATE
   // (although these could be overridden later e.g. during checkForEXT, depending on file type)
+  // on entry, the variable named "entry" is a file handle already opened for the file you want to play
+  // and filename and filenameExt are already set
   #ifdef Use_CAS
   setCASBaud();
   #endif
-
-  // on entry, currentFile is already pointing to the file entry you want to play
-  // and fileName is already set
-  if(!entry.open(currentDir, currentFile, O_RDONLY)) {
-  //  printtextF(PSTR("Error Opening File"),0);
-  }
 
 #ifdef ID11CDTspeedup
   AMScdt = false;
@@ -101,8 +97,7 @@ void UniPlay(){
   currentBit=0;                               // fallo reproducción de .tap tras .tzx
   bytesRead=0;                                //start of file
   currentTask=TASK::INIT;                     //
-  const char * filenameExt = strrchr(fileName,'.') + 1;
-  checkForEXT(filenameExt);
+  checkForEXT();
   isStopped=false;
   
   clearBuffer();

--- a/MaxDuino/configs_sanity.h
+++ b/MaxDuino/configs_sanity.h
@@ -15,6 +15,10 @@
 #endif
 
 
+#if (defined(LOAD_EEPROM_LOGO) && defined(LOAD_MEM_LOGO)) || (defined(LOAD_EEPROM_LOGO) && defined(LOAD_EEPROM_LOGO_MEM_FALLBACK)) || (defined(LOAD_MEM_LOGO) && defined(LOAD_EEPROM_LOGO_MEM_FALLBACK))
+#error Can only define one of: LOAD_EEPROM_LOGO, LOAD_MEM_LOGO, LOAD_EEPROM_LOGO_MEM_FALLBACK
+#endif
+
 #ifdef RECORD
 
 #if defined(RECORD_CAS_MSX) && !defined(Use_CAS)

--- a/MaxDuino/file_utils.h
+++ b/MaxDuino/file_utils.h
@@ -14,6 +14,7 @@ extern unsigned long filesize;
 extern unsigned long bytesRead;
 extern uint16_t currentFile; //File index (per filesystem) of current file, relative to current directory (pointed to by currentDir)
 extern char fileName[];
+extern const char * filenameExt;
 
 #define FILEBUFFER_SIZE 20
 extern byte filebuffer[]; // used for small reads from files (readfile, ReadByte, etc use this), sized for the largest header read

--- a/MaxDuino/menu.cpp
+++ b/MaxDuino/menu.cpp
@@ -25,6 +25,10 @@
 #include "product_strings.h"
 #include "current_settings.h"
 
+#ifdef MENU_HAS_REBOOT
+extern void (*resetFunc) (void);
+#endif
+
 #if defined(lineaxy)
 #define M_LINE2 lineaxy
 #else
@@ -44,6 +48,9 @@ enum MenuItems{
 #ifdef MenuBLK2A
   BLK2A,
 #endif
+#ifdef MENU_HAS_REBOOT
+  REBOOT,
+#endif
   _Num_Menu_Items
 };
 
@@ -59,6 +66,10 @@ const char MENU_ITEM_TSX[] PROGMEM = "TSXCzxpUEFSW ?";
 #ifdef MenuBLK2A
 const char MENU_ITEM_BLK2A[] PROGMEM = "Skip BLK:2A ?";
 #endif
+#ifdef MENU_HAS_REBOOT
+const char MENU_ITEM_REBOOT[] PROGMEM = "REBOOT?";
+#endif
+
 const char* const MENU_ITEMS[] PROGMEM = {
   MENU_ITEM_VERSION,
   MENU_ITEM_BAUD_RATE,
@@ -71,6 +82,9 @@ const char* const MENU_ITEMS[] PROGMEM = {
   MENU_ITEM_TSX,
 #ifdef MenuBLK2A
   MENU_ITEM_BLK2A,
+#endif
+#ifdef MENU_HAS_REBOOT
+  MENU_ITEM_REBOOT
 #endif
 };
 
@@ -315,7 +329,14 @@ void menuMode()
           case MenuItems::BLK2A:
             doOnOffSubmenu(skip2A);
             break;
-        #endif     
+        #endif    
+
+        #ifdef MENU_HAS_REBOOT
+          case MenuItems::REBOOT:
+            clear_display();
+            resetFunc();
+        #endif
+
       }
       lastbtn=true;
       updateScreen=true;

--- a/MaxDuino/record.cpp
+++ b/MaxDuino/record.cpp
@@ -112,7 +112,7 @@ static void drawRecordingScreenOnce()
 }
 
 static bool has_ext_ci() {
-  const char * filenameExt = strrchr(fileName,'.') + 1;
+  filenameExt = strrchr(fileName,'.') + 1;
   return (strcasecmp_P(filenameExt, ext3) == 0);
 }
 

--- a/MaxDuino/userARDUINO_ESP8266_WEMOS_D1MINIconfig.h
+++ b/MaxDuino/userARDUINO_ESP8266_WEMOS_D1MINIconfig.h
@@ -7,6 +7,7 @@
 
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -97,10 +98,12 @@
 
 //#define COMPRESS_REPEAT_ROW
 //#define EEPROM_LOGO_COMPRESS
-#define LOAD_MEM_LOGO             
+//#define LOAD_MEM_LOGO             
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 //#define LOAD_EEPROM_LOGO 
+#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userATMEGA32U4config.h
+++ b/MaxDuino/userATMEGA32U4config.h
@@ -104,7 +104,9 @@
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userD1_MINI32config.h
+++ b/MaxDuino/userD1_MINI32config.h
@@ -8,6 +8,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -96,10 +97,12 @@
 
 //#define COMPRESS_REPEAT_ROW
 //#define EEPROM_LOGO_COMPRESS
-#define LOAD_MEM_LOGO
+//#define LOAD_MEM_LOGO
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 //#define LOAD_EEPROM_LOGO 
+#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userEVERYconfig.h
+++ b/MaxDuino/userEVERYconfig.h
@@ -3,6 +3,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -112,7 +113,9 @@
 #define LOAD_MEM_LOGO             // 4808/4809 don't have as much eeprom as other devices, and they have more flash, so usually you load mem logo, not eeprom
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 //#define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userMAXconfig.h
+++ b/MaxDuino/userMAXconfig.h
@@ -3,6 +3,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -92,7 +93,8 @@
 //#define EEPROM_LOGO_COMPRESS
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
-#define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO 
+#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
 #define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 

--- a/MaxDuino/userMAXconfig.h
+++ b/MaxDuino/userMAXconfig.h
@@ -77,7 +77,7 @@
 #define BLOCKTAP_IN
 #define OLEDPRINTBLOCK 
 #define LOAD_EEPROM_SETTINGS
-#define EEPROM_CONFIG_BYTEPOS  1023     // Byte position to save configuration
+#define EEPROM_CONFIG_BYTEPOS  1024     // Byte position to save configuration - AFTER the logo since this device has plenty of EEPROM (4K)
 #define OSTATUSLINE
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // EEPROM LOGO. How to move to EEPROM, saving memory:
@@ -94,6 +94,7 @@
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userRPI_PICOconfig.h
+++ b/MaxDuino/userRPI_PICOconfig.h
@@ -8,6 +8,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -96,10 +97,12 @@
 
 //#define COMPRESS_REPEAT_ROW
 //#define EEPROM_LOGO_COMPRESS
-#define LOAD_MEM_LOGO
+//#define LOAD_MEM_LOGO
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 //#define LOAD_EEPROM_LOGO 
+#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userSEEEDUINO_XIAO_ESP32C3config.h
+++ b/MaxDuino/userSEEEDUINO_XIAO_ESP32C3config.h
@@ -15,6 +15,7 @@
 
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -103,10 +104,12 @@
 
 //#define COMPRESS_REPEAT_ROW
 //#define EEPROM_LOGO_COMPRESS
-#define LOAD_MEM_LOGO
+//#define LOAD_MEM_LOGO
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
-//#define LOAD_EEPROM_LOGO          // No point using EEPROM for ESP32C3 logo, since EEPROM is emulated in flash, and flashing new firmware erases EEPROM (and also ESP32C3 has lots of spare flash)
+//#define LOAD_EEPROM_LOGO          // With PlatformIO certainly, reflashing ESP32C3 does not erase the emulated EEPROM area, so this works ok
+#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userSEEEDUINO_XIAO_M0config.h
+++ b/MaxDuino/userSEEEDUINO_XIAO_M0config.h
@@ -99,10 +99,11 @@
 
 //#define COMPRESS_REPEAT_ROW
 //#define EEPROM_LOGO_COMPRESS
-#define LOAD_MEM_LOGO
+//#define LOAD_MEM_LOGO
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
-//#define LOAD_EEPROM_LOGO          // Xiao M0 uses emulated eeprom and a custom build script to preserve across reflash, so you can now use LOAD_EEPROM_LOGO if you want to!
+#define LOAD_EEPROM_LOGO          // Xiao M0 uses emulated eeprom and a custom build script to preserve across reflash, so you can now use LOAD_EEPROM_LOGO if you want to!
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userSEEEDUINO_XIAO_M0config.h
+++ b/MaxDuino/userSEEEDUINO_XIAO_M0config.h
@@ -11,6 +11,7 @@
 
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -101,7 +102,8 @@
 //#define EEPROM_LOGO_COMPRESS
 //#define LOAD_MEM_LOGO
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
-#define LOAD_EEPROM_LOGO          // Xiao M0 uses emulated eeprom and a custom build script to preserve across reflash, so you can now use LOAD_EEPROM_LOGO if you want to!
+//#define LOAD_EEPROM_LOGO          // Xiao M0 uses emulated eeprom and a custom build script to preserve across reflash, so you can now use LOAD_EEPROM_LOGO if you want to!
+#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
 #define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 

--- a/MaxDuino/userSTM32config.h
+++ b/MaxDuino/userSTM32config.h
@@ -3,6 +3,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -97,7 +98,9 @@
 #define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 //#define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userSTM32config0.h
+++ b/MaxDuino/userSTM32config0.h
@@ -4,6 +4,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -97,7 +98,9 @@
 #define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 //#define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userconfig0.h
+++ b/MaxDuino/userconfig0.h
@@ -6,6 +6,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -99,7 +100,9 @@
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userconfig1.h
+++ b/MaxDuino/userconfig1.h
@@ -6,6 +6,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -99,7 +100,9 @@
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userconfig10.h
+++ b/MaxDuino/userconfig10.h
@@ -6,6 +6,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -98,7 +99,9 @@
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userconfig2.h
+++ b/MaxDuino/userconfig2.h
@@ -6,6 +6,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -98,7 +99,9 @@
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userconfig3.h
+++ b/MaxDuino/userconfig3.h
@@ -6,6 +6,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -98,7 +99,9 @@
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userconfig4.h
+++ b/MaxDuino/userconfig4.h
@@ -6,6 +6,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -98,7 +99,9 @@
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userconfig5.h
+++ b/MaxDuino/userconfig5.h
@@ -6,6 +6,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -98,7 +99,9 @@
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userconfig6.h
+++ b/MaxDuino/userconfig6.h
@@ -6,6 +6,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 //#define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -98,7 +99,9 @@
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userconfig7.h
+++ b/MaxDuino/userconfig7.h
@@ -6,6 +6,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 #define AYPLAY
 #define MenuBLK2A
 #define ID11CDTspeedup
@@ -100,7 +101,9 @@
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userconfig8.h
+++ b/MaxDuino/userconfig8.h
@@ -6,6 +6,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 //#define AYPLAY
 #define MenuBLK2A
 //#define ID11CDTspeedup
@@ -98,7 +99,9 @@
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO

--- a/MaxDuino/userconfig9.h
+++ b/MaxDuino/userconfig9.h
@@ -6,6 +6,7 @@
 /*                 Add // at the beginning of lines to comment and remove selected option                                */
 //**************************************  OPTIONAL USE TO SAVE SPACE  ***************************************************//
 #define Use_MENU                          // removing menu saves space
+//#define MENU_HAS_REBOOT  // Add an entry to reboot device from menu
 //#define AYPLAY
 //#define MenuBLK2A
 //#define ID11CDTspeedup
@@ -98,7 +99,9 @@
 //#define LOAD_MEM_LOGO             // legacy, logo is not in EEPROM then wasting memory.
 //#define RECORD_EEPROM_LOGO        // Uncommenting RECORD_EEPROM deactivates #define Use_MENU
 #define LOAD_EEPROM_LOGO 
+//#define LOAD_EEPROM_LOGO_MEM_FALLBACK  // Try loading logo from eeprom, but if it looks like no logo is stored then fallback to the compiled-in mem logo
 #define LOGO_FADE_IN 2500 /* Number of milliseconds for logo animation */
+//#define EEPROM_LOGO_BMP_LOADER  // Adds support for file browser to load .bmp file and write it to EEPROM
 
 // for list of logos, see filenames in "logos" folder, and remove the logo_ prefix from the filename
 // either use the below defines, or use -DLOGO


### PR DESCRIPTION
*  Load bitmap (.bmp, 128x64 or 128x32 , 1 bpp) and write to EEPROM logo.  Works with existing LOAD_EEPROM_LOGO.
*  Add a new "LOAD_EEPROM_LOGO_MEM_FALLBACK" :  try loading EEPROM logo but fall-back to mem (firmware) logo if EEPROM logo hasn't been written yet, or is blank.  (You can write a 'blank' .bmp to reset it!)
*  Added Menu option to Reboot device, good for testing.