### PR TITLE
Simplify i2c configuration and add another library, Acewire

### DIFF
--- a/MaxDuino/constants.h
+++ b/MaxDuino/constants.h
@@ -6,6 +6,7 @@
 #define _I2C_Impl_SoftI2CMaster (0)
 #define _I2C_Impl_SoftWire (1)
 #define _I2C_Impl_Wire (2)
+#define _I2C_Impl_AceWire (3)
 
 
 enum class CASDUINO_FILETYPE : byte {

--- a/MaxDuino/i2c.cpp
+++ b/MaxDuino/i2c.cpp
@@ -1,16 +1,29 @@
 #ifndef CLI
 #include "configs.h"
-#include "i2c_config.h"
+#include "Arduino.h"
 #include "i2c.h"
 
-#if (I2C_Library_Used == _I2C_Impl_SoftI2CMaster)
+#if (I2C_Library_Preference == _I2C_Impl_AceWire) && defined(ARDUINO_ARCH_AVR)
+  #warning I2c using ACEWIRE interface with fast AVR optimisations
+  #include <digitalWriteFast.h>
+  #include <ace_wire/SimpleWireFastInterface.h>
+  using ace_wire::SimpleWireFastInterface;
+  SimpleWireFastInterface<SDA, SCL, I2C_DELAY_MICROS> i2cAceWire;
+#elif (I2C_Library_Preference == _I2C_Impl_AceWire)
+  #warning I2c using ACEWIRE interface without fast optimisations
+  #include <AceWire.h>
+  SimpleWireInterface i2cAceWire(SDA, SCL, I2C_DELAY_MICROS);
+#elif (I2C_Library_Preference == _I2C_Impl_SoftI2CMaster)
+  #warning I2C using SOFTI2CMaster interface
   #undef USE_SOFT_I2C_MASTER_H_AS_PLAIN_INCLUDE
   #undef _SOFTI2C_HPP
   #include <SoftI2CMaster.h>
-#elif (I2C_Library_Used == _I2C_Impl_SoftWire)
+#elif (I2C_Library_Preference == _I2C_Impl_SoftWire)
+  #warning I2C using SoftWire interface
   #include <SoftWire.h>
   SoftWire Wire = SoftWire();  
 #else
+  #warning I2C using standard Wire interface
   #include <Wire.h>
 #endif
 #endif

--- a/MaxDuino/i2c.h
+++ b/MaxDuino/i2c.h
@@ -19,51 +19,55 @@
   #endif
 #endif
 
-#if defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega328P__)
-  #if I2C_Library_Preference == _I2C_Impl_SoftI2CMaster
-    #define I2C_Library_Used (_I2C_Impl_SoftI2CMaster)
-  #elif I2C_Library_Preference == _I2C_Impl_SoftWire
-    #define I2C_Library_Used (_I2C_Impl_SoftWire)
+
+#if (I2C_Library_Preference == _I2C_Impl_SoftI2CMaster)
+  // these #defines in the section are ONLY used by the SoftI2CMaster library
+  #if (defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__))
+    #define SDA_PORT PORTD
+    #define SDA_PIN 1 
+    #define SCL_PORT PORTD
+    #define SCL_PIN 0 
   #else
-    #warning Wire library uses a lot of firmware space, you would be better off using SoftI2CMaster
-    #define I2C_Library_Used (_I2C_Impl_Wire)
+    #define SDA_PORT PORTC
+    #define SDA_PIN 4 
+    #define SCL_PORT PORTC
+    #define SCL_PIN 5
   #endif
-#else
-  #if I2C_Library_Preference == _I2C_Impl_SoftI2CMaster
-    #warning This chip does not support SoftI2CMaster. Using default.
-  #endif
-  #if I2C_Library_Preference == _I2C_Impl_SoftWire
-    #warning This chip does not support SoftWire. Using default.
-  #endif
-  #define I2C_Library_Used (_I2C_Impl_Wire)
 #endif
 
-#if (defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__))
-  #define SDA_PORT PORTD
-  #define SDA_PIN 1 
-  #define SCL_PORT PORTD
-  #define SCL_PIN 0 
-#else
-  #define SDA_PORT PORTC
-  #define SDA_PIN 4 
-  #define SCL_PORT PORTC
-  #define SCL_PIN 5
-//  #define I2C_HARDWARE 1   // requires more thorough testing. Needs additional delay in init_OLED e.g. 100ms after sendcommand(0xAF)
+
+#if (I2C_Library_Preference == _I2C_Impl_AceWire)
+  #ifndef I2C_DELAY_MICROS
+    #define I2C_DELAY_MICROS ((1000000UL / (2UL * I2CCLOCK)) > 0 ? (1000000UL / (2UL * I2CCLOCK)) : 1)
+  #endif
 #endif
 
-#if (I2C_Library_Used == _I2C_Impl_SoftI2CMaster)
-  // ideally I'd do this:
+
+#if (I2C_Library_Preference == _I2C_Impl_AceWire) && defined(ARDUINO_ARCH_AVR)
+  #include <digitalWriteFast.h>
+  #include <ace_wire/SimpleWireFastInterface.h>
+  using ace_wire::SimpleWireFastInterface;
+  extern SimpleWireFastInterface<SDA, SCL, I2C_DELAY_MICROS> i2cAceWire;
+  #define mx_i2c_init() i2cAceWire.begin()
+  #define mx_i2c_start(address) i2cAceWire.beginTransmission(address)
+  #define mx_i2c_write(byte) i2cAceWire.write(byte)
+  #define mx_i2c_end() i2cAceWire.endTransmission()
+
+#elif (I2C_Library_Preference == _I2C_Impl_SoftI2CMaster)
+
+// ideally I'd do this:
   //     #define USE_SOFT_I2C_MASTER_H_AS_PLAIN_INCLUDE
   //     #include <SoftI2CMaster.h>
   // but as of 2.1.9 it appears it still doesn't work properly (at least not with platform io)
   // so I'll forward-declare everything myself:
-  #ifndef I2C_WRITE
-  #define I2C_WRITE 0
-  #endif
   bool __attribute__ ((noinline)) i2c_init(void) __attribute__ ((used));
   bool __attribute__ ((noinline)) i2c_start(uint8_t addr) __attribute__ ((used));
   void __attribute__ ((noinline)) i2c_stop(void) asm("ass_i2c_stop") __attribute__ ((used));
   bool __attribute__ ((noinline)) i2c_write(uint8_t value) asm("ass_i2c_write") __attribute__ ((used));
+
+  #ifndef I2C_WRITE
+  #define I2C_WRITE 0
+  #endif
 
   #define mx_i2c_init() i2c_init()
   #define mx_i2c_start(address) i2c_start((address<<1)|I2C_WRITE)
@@ -71,11 +75,15 @@
   #define mx_i2c_end() i2c_stop()
 
 #else
-  // Wire or SoftWire
-  #if (I2C_Library_Used == _I2C_Impl_SoftWire)
+  // Wire, SoftWire, or AceWire (non-AVR)
+  #if (I2C_Library_Preference == _I2C_Impl_SoftWire)
     extern SoftWire Wire;
-  #elif (I2C_Library_Used == _I2C_Impl_Wire)
+  #elif (I2C_Library_Preference == _I2C_Impl_Wire)
     #include <Wire.h>
+  #elif (I2C_Library_Preference == _I2C_Impl_AceWire)
+    #include <AceWire.h>
+    using ace_wire::SimpleWireInterface;
+    extern SimpleWireInterface i2cAceWire;
   #else
     #error Unknown I2C library configuration
   #endif
@@ -93,15 +101,23 @@
     #define I2C_WIRE_CLASS Wire
   #endif
 
-  #define mx_i2c_init() I2C_WIRE_CLASS.begin();\
-                        I2C_WIRE_CLASS.setClock(I2CCLOCK)
-  #define mx_i2c_start(address) I2C_WIRE_CLASS.beginTransmission(address)
-  #define mx_i2c_write(byte) I2C_WIRE_CLASS.write(byte)
-  #define mx_i2c_end() I2C_WIRE_CLASS.endTransmission()
+  #if (I2C_Library_Preference == _I2C_Impl_Wire) || (I2C_Library_Preference == _I2C_Impl_SoftWire)
+    #define mx_i2c_init() I2C_WIRE_CLASS.begin();\
+                          I2C_WIRE_CLASS.setClock(I2CCLOCK)
+    #define mx_i2c_start(address) I2C_WIRE_CLASS.beginTransmission(address)
+    #define mx_i2c_write(byte) I2C_WIRE_CLASS.write(byte)
+    #define mx_i2c_end() I2C_WIRE_CLASS.endTransmission()
+  #else // (I2C_Library_Preference == _I2C_Impl_AceWire)
+    #define mx_i2c_init() i2cAceWire.begin()
+    #define mx_i2c_start(address) i2cAceWire.beginTransmission(address)
+    #define mx_i2c_write(byte) i2cAceWire.write(byte)
+    #define mx_i2c_end() i2cAceWire.endTransmission()
+  #endif
 
 #endif
 
 #if defined(P8544)
+// this really does not belong here
   #include <pcd8544.h>
   #define ADMAX 1023
   #define ADPIN 0

--- a/MaxDuino/i2c_config.h
+++ b/MaxDuino/i2c_config.h
@@ -6,10 +6,22 @@
 
 // preferred I2C implementation
 #ifndef I2C_Library_Preference
-#define I2C_Library_Preference _I2C_Impl_SoftI2CMaster
-//#define I2C_Library_Preference _I2C_Impl_SoftWire
+#if defined(__AVR_ATmega2560__) || defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega328P__)
+    #define I2C_Library_Preference _I2C_Impl_AceWire
+//    #define I2C_Library_Preference _I2C_Impl_SoftI2CMaster
+#else
+    #define I2C_Library_Preference _I2C_Impl_Wire
+#endif
 #endif
 
-#define I2CFAST // if defined, I2C bus runs at 400kHz, instead of 100kHz default
+// I2CFAST, if defined, I2C bus runs at 400kHz, instead of 100kHz default
+#define I2CFAST
+
+// I2C_DELAY_MICROS, only used by Acewire initialisation
+// How many microseconds to wait between I2C requests
+// Default is calculated based on I2CCLOCK (which is calculated based on I2CFAST, above)
+// Defining here to be 0 means run as fast as possible (which is around 400kHz if using SimpleWireFastInterface on AVR)
+// If using acewire and I2C is locking up, you may want to comment out the below, or set to some other value > 0 
+#define I2C_DELAY_MICROS 0
 
 #endif // I2C_CONFIG_H_INCLUDED

--- a/MaxDuino/pinSetup.cpp
+++ b/MaxDuino/pinSetup.cpp
@@ -8,8 +8,10 @@
 
 #if defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_MBED_RP2040) || defined(ARDUINO_ARCH_RP2350)
 #include <SPI.h>
-#include <Wire.h>
 #include "i2c.h"
+#if (I2C_Library_Preference == _I2C_Impl_Wire) || (I2C_Library_Preference == _I2C_Impl_SoftWire)
+#include <Wire.h>
+#endif
 #endif
 
 void pinsetup()
@@ -218,8 +220,10 @@ void pinsetup()
   pinMode(btnMotor, INPUT_PULLUP);
   #endif
 
+#if (I2C_Library_Preference == _I2C_Impl_Wire) || (I2C_Library_Preference == _I2C_Impl_SoftWire)
   I2C_WIRE_CLASS.setSDA(RP2040_I2C_SDA_PIN);
   I2C_WIRE_CLASS.setSCL(RP2040_I2C_SCL_PIN);
+#endif
 
   // XIAO boards use SPI0 (SD pins D8/D9/D10 = GPIO 2/4/3 match default SPI0 pins).
   // Pico and others use SPI1 with default pins (GPIO 10/11/12).

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,8 @@ src_dir = ./MaxDuino
 lib_deps = 
 	greiman/SdFat@2.2.3
 	https://github.com/felias-fogg/SoftI2CMaster.git#V2.1.9
+	bxparks/AceWire@^0.4.1
+	watterott/digitalWriteFast@^1.0.0
 extra_scripts = 
 	pre:extra_script.py
 build_flags =
@@ -66,7 +68,6 @@ build_flags =
 	${common.samd21_build_flags}
 	-DUSE_TINYUSB
 	-I "${PROJECT_CORE_DIR}/packages/framework-arduino-samd-seeed/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
-	-DI2C_Library_Preference=_I2C_Impl_Wire ; silences warning about unsupported SoftI2CMaster
 
 [env:seeed_xiao_samd21_ricky_test_board]
 extends = env:seeed_xiao_samd21
@@ -213,8 +214,6 @@ build_flags =
 extends = base
 platform = espressif32
 board = seeed_xiao_esp32c3
-build_flags = 
-	-DI2C_Library_Preference=_I2C_Impl_Wire ; silences warning about unsupported SoftI2CMaster
 
 [env:seeed_xiao_ESP32C3_ricky_test_board]
 extends = base
@@ -222,7 +221,6 @@ platform = espressif32@5.4.0
 board = seeed_xiao_esp32c3
 build_flags = 
 	-DRICKY_TEST_BOARD
-	-DI2C_Library_Preference=_I2C_Impl_Wire ; silences warning about unsupported SoftI2CMaster
 
 [env:STM32_MapleMiniDuino]
 extends = base
@@ -246,8 +244,6 @@ platform = https://github.com/maxgerhardt/platform-raspberrypi.git  ; official P
 board = pico
 board_build.core = earlephilhower
 board_build.filesystem_size = 0m ; not using LittleFS (.. yet?)
-build_flags =
-	-DI2C_Library_Preference=_I2C_Impl_Wire ; silences warning about unsupported SoftI2CMaster
 
 [env:seeed_xiao_rp2040]
 extends = base
@@ -255,8 +251,6 @@ platform = https://github.com/maxgerhardt/platform-raspberrypi.git  ; official P
 board = seeed_xiao_rp2040
 board_build.core = earlephilhower
 board_build.filesystem_size = 0m ; not using LittleFS (.. yet?)
-build_flags =
-	-DI2C_Library_Preference=_I2C_Impl_Wire ; silences warning about unsupported SoftI2CMaster
 
 [env:seeed_xiao_rp2040_ricky_test_board]
 extends = base
@@ -265,7 +259,6 @@ board = seeed_xiao_rp2040
 board_build.core = earlephilhower
 board_build.filesystem_size = 0m ; not using LittleFS (.. yet?)
 build_flags =
-	-DI2C_Library_Preference=_I2C_Impl_Wire ; silences warning about unsupported SoftI2CMaster
 	-DRICKY_TEST_BOARD
 
 [env:seeed_xiao_rp2350]
@@ -274,8 +267,6 @@ platform = https://github.com/maxgerhardt/platform-raspberrypi.git  ; official P
 board = seeed_xiao_rp2350
 board_build.core = earlephilhower
 board_build.filesystem_size = 0m ; not using LittleFS (.. yet?)
-build_flags =
-	-DI2C_Library_Preference=_I2C_Impl_Wire ; silences warning about unsupported SoftI2CMaster
 
 [env:wemos_d1_mini32]
 extends = base
@@ -283,7 +274,6 @@ platform = espressif32
 board = wemos_d1_mini32
 build_flags =
 	-DWEMOS_D1_MINI32=1 ; just used to identify the board (i.e. pin layout)
-	-DI2C_Library_Preference=_I2C_Impl_Wire ; silences warning about unsupported SoftI2CMaster
 
 [env:wemos_d1_mini32_ricky_test_board]
 extends = base
@@ -291,5 +281,4 @@ platform = espressif32
 board = wemos_d1_mini32
 build_flags =
 	-DWEMOS_D1_MINI32=1 ; just used to identify the board (i.e. pin layout)
-	-DI2C_Library_Preference=_I2C_Impl_Wire ; silences warning about unsupported SoftI2CMaster
 	-DRICKY_TEST_BOARD


### PR DESCRIPTION
Acewire is smaller, and faster than SoftI2CMaster on AVR.  So, Acewire is now the default on nano/32u4/mega.
Acewire optional on other boards too, but default is still Wire (which is faster)