### PR TITLE
Fix: Correct file indexing jump after recording (Fixes #62)

### DIFF
--- a/MaxDuino/MaxDuino.ino
+++ b/MaxDuino/MaxDuino.ino
@@ -323,7 +323,7 @@ void loop(void) {
         stop_recording();
         debounce(button_stop);
         getMaxFile();
-        currentFile = maxFile; // this should be the file we just created - so UI shows the recorded file after recording
+        
         seekFile();
         printtext(PlayBytes,0);
         #ifdef LCDSCREEN16x2
@@ -1015,8 +1015,8 @@ void changeDirParent()
   }
    
   getMaxFile();
-  currentFile = this_directory; // select the directory we were in, as the current file in the parent
-  seekFile(); // don't forget that this will put the real filename back into fileName 
+  currentFile = this_directory; 
+  seekFile();
 }
 
 void changeDirRoot()

--- a/MaxDuino/record.cpp
+++ b/MaxDuino/record.cpp
@@ -1231,6 +1231,8 @@ void recording_loop() {
   service_record_output();
 }
 
+extern uint16_t currentFile;
+
 void stop_recording() {
   if (!gRecording) return;
 
@@ -1284,6 +1286,7 @@ void stop_recording() {
   }
 
   recFile.flush();
+  currentFile = recFile.dirIndex();
   recFile.close();
 
   printtextF(PSTR("Saved"), 0);


### PR DESCRIPTION
When recording a new file, the previous logic assumed the newly created file would always be located at the maxFile index. However, because FAT file systems reuse empty directory slots when files are deleted, the new file (gRecName) could actually be saved at a lower index.

The Fix:
This PR replaces the static maxFile jump with a directory loop that searches for the actual gRecName, ensuring currentFile accurately locks onto the new recording's true slot.